### PR TITLE
Corrected line to filter out buku warning message

### DIFF
--- a/rofi-buku
+++ b/rofi-buku
@@ -51,7 +51,7 @@ Use <span color='${help_color}'>${switch_view}</span> to switch View. <span colo
         content=$(parseBuku)
         menu=$(echo "${content}" | _rofi -p '> ' -filter "${filter}" -mesg "${HELP}" -kb-custom-1 "${new_bookmark}" -kb-custom-2 "${switch_view}" -kb-custom-3 "${actions}" -kb-custom-4 "${edit}" -kb-custom-5 "${delete}" -kb-custom-6 "${copy}")
     elif [[ $mode == "tags" ]]; then
-        menu=$(buku --np --st | grep -v -e '^waiting for input$' -e '^$' | awk '{$NF=""; print $0}' | cut -d ' ' -f2  | _rofi -p '> ' -mesg "${HELP}" -kb-custom-1 "${new_bookmark}" -kb-custom-2 "${switch_view}" -kb-custom-3 "${actions}" -kb-custom-4 "${edit}" -kb-custom-5 "${delete}")
+        menu=$(buku --np --st | grep -v -e 'waiting for input' -e '^$' | awk '{$NF=""; print $0}' | cut -d ' ' -f2  | _rofi -p '> ' -mesg "${HELP}" -kb-custom-1 "${new_bookmark}" -kb-custom-2 "${switch_view}" -kb-custom-3 "${actions}" -kb-custom-4 "${edit}" -kb-custom-5 "${delete}")
     fi
     val=$?
     if [[ $val -eq 1 ]]; then
@@ -264,7 +264,7 @@ addMark () {
 }
 
 addTags () {
-  inserttags=$(buku --np --st | grep -v '^waiting for input$' | awk '{$NF=""; print $0}' | cut -d ' ' -f2- | _rofi -p '> ' -mesg "Add some tags. Separate tags with ', '")
+  inserttags=$(buku --np --st | grep -v 'waiting for input' | awk '{$NF=""; print $0}' | cut -d ' ' -f2- | _rofi -p '> ' -mesg "Add some tags. Separate tags with ', '")
   val=$?
 
   if [[ $val -eq 1 ]]; then
@@ -285,7 +285,7 @@ addTags () {
 }
 
 parseBuku () {
-  buku --nc -p | grep -v '^waiting for input$' | gawk -v max="$max_str_width" -v type="$display_type" '
+  buku --nc -p | grep -v 'waiting for input' | gawk -v max="$max_str_width" -v type="$display_type" '
     BEGIN { RS=""; FS="\n" }
     {
       id = gensub(/([0-9]+)\.(.*)/, "\\1", "g", $1)
@@ -340,7 +340,7 @@ getId () {
 }
 
 getTitleFromId () {
-  buku --nc -p "${1}" | grep -v '^waiting for input$' | gawk '
+  buku --nc -p "${1}" | grep -v 'waiting for input' | gawk '
     BEGIN { RS=""; FS="\n" }
 
     { print gensub(/[0-9]+\.\s*(.*)/, "\\1", "g", $1) }
@@ -348,7 +348,7 @@ getTitleFromId () {
 }
 
 getUrlFromId () {
-  buku --nc -p "${1}" | grep -v '^waiting for input$' | gawk '
+  buku --nc -p "${1}" | grep -v 'waiting for input' | gawk '
     BEGIN { RS=""; FS="\n" }
 
     { print gensub(/\s+> (.*)/, "\\1", "g", $2) }
@@ -356,7 +356,7 @@ getUrlFromId () {
 }
 
 getCommentFromId () {
-  buku --nc -p "${1}" | grep -v '^waiting for input$' | gawk '
+  buku --nc -p "${1}" | grep -v 'waiting for input' | gawk '
     BEGIN { RS=""; FS="\n" }
 
     {
@@ -367,7 +367,7 @@ getCommentFromId () {
 }
 
 getTagsFromId () {
-  buku --nc -p "${1}" | grep -v '^waiting for input$' | gawk '
+  buku --nc -p "${1}" | grep -v 'waiting for input' | gawk '
     BEGIN { RS=""; FS="\n" }
 
     {

--- a/rofi-buku
+++ b/rofi-buku
@@ -14,6 +14,7 @@ new_bookmark="Alt+n"
 actions="Alt+a"
 edit="Alt+e"
 delete="Alt+d"
+copy="Alt+c"
 
 # colors
 help_color="#334433"
@@ -44,11 +45,11 @@ fi
 
 
 main () {
-    HELP="Welcome to Buku. Use <span color='${help_color}'>${new_bookmark}</span> to add a new Bookmark
+    HELP="Welcome to Buku. Use <span color='${help_color}'>${new_bookmark}</span> to add a new Bookmark, <span color='${help_color}'>${copy}</span> to copy URL to clipboard
 Use <span color='${help_color}'>${switch_view}</span> to switch View. <span color='${help_color}'>${actions}</span> for actions"
     if [[ $mode == "bookmarks" ]]; then
         content=$(parseBuku)
-        menu=$(echo "${content}" | _rofi -p '> ' -filter "${filter}" -mesg "${HELP}" -kb-custom-1 "${new_bookmark}" -kb-custom-2 "${switch_view}" -kb-custom-3 "${actions}" -kb-custom-4 "${edit}" -kb-custom-5 "${delete}")
+        menu=$(echo "${content}" | _rofi -p '> ' -filter "${filter}" -mesg "${HELP}" -kb-custom-1 "${new_bookmark}" -kb-custom-2 "${switch_view}" -kb-custom-3 "${actions}" -kb-custom-4 "${edit}" -kb-custom-5 "${delete}" -kb-custom-6 "${copy}")
     elif [[ $mode == "tags" ]]; then
         menu=$(buku --np --st | grep -v -e '^waiting for input$' -e '^$' | awk '{$NF=""; print $0}' | cut -d ' ' -f2  | _rofi -p '> ' -mesg "${HELP}" -kb-custom-1 "${new_bookmark}" -kb-custom-2 "${switch_view}" -kb-custom-3 "${actions}" -kb-custom-4 "${edit}" -kb-custom-5 "${delete}")
     fi
@@ -80,6 +81,10 @@ Use <span color='${help_color}'>${switch_view}</span> to switch View. <span colo
         elif [[ $mode == "tags" ]]; then
             filter="${menu}" mode="bookmarks" main
         fi
+    elif [[ $val -eq 15 ]]; then
+        id=$(getId "$content" "$menu")
+        url="$(getUrlFromId "${id}")"
+        echo -n "$url" | xclip -selection clipboard
     fi
 }
 


### PR DESCRIPTION
When called non-interatively, the buku script returns a message.
That message was modified recently on the `buku` source code, breaking
the grep filter. See https://github.com/jarun/buku/issues/513